### PR TITLE
ISS-2. Remove Override from createJSModules

### DIFF
--- a/android/src/main/java/com/rndetectnavbarandroid/RNDetectNavbarAndroidPackage.java
+++ b/android/src/main/java/com/rndetectnavbarandroid/RNDetectNavbarAndroidPackage.java
@@ -17,7 +17,6 @@ public class RNDetectNavbarAndroidPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
Fix the issue https://github.com/lequanghuylc/react-native-detect-navbar-android/issues/2