### PR TITLE
Update build Gradle to be compliant with modern gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion rootProject.properties.get('compileSdkVersion', 23)
+    buildToolsVersion rootProject.properties.get('buildToolsVersion', "23.0.1")
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion rootProject.properties.get('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This uses the new implementation syntax instead of compile which errors now with:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

I also correctly get's the sdk versions from the rootProject. 